### PR TITLE
flaky test fix PR

### DIFF
--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestAbstractHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestAbstractHttpServletRequest.java
@@ -18,6 +18,7 @@
 package org.apache.servicecomb.foundation.vertx.http;
 
 import java.util.Collections;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -39,7 +40,9 @@ public class TestAbstractHttpServletRequest {
     MatcherAssert.assertThat(Collections.list(request.getAttributeNames()), Matchers.contains(key));
 
     request.setAttribute("a2", "v");
-    MatcherAssert.assertThat(Collections.list(request.getAttributeNames()), Matchers.contains(key, "a2"));
+    List<String> attributeList = Collections.list(request.getAttributeNames());
+    Collections.sort(Collections.list(request.getAttributeNames()));
+    MatcherAssert.assertThat(attributeList, Matchers.contains(key, "a2"));
 
     request.removeAttribute(key);
     Assertions.assertNull(request.getAttribute(key));

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestStandardHttpServletRequestEx.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestStandardHttpServletRequestEx.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.List;
 
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -131,7 +132,9 @@ public class TestStandardHttpServletRequestEx {
       }
     };
 
-    MatcherAssert.assertThat(Collections.list(requestEx.getParameterNames()), Matchers.contains("p1", "p2"));
+    List<String> paramList = Collections.list(requestEx.getParameterNames());
+    Collections.sort(paramList);
+    MatcherAssert.assertThat(paramList, Matchers.contains("p1", "p2"));
     MatcherAssert.assertThat(requestEx.getParameterValues("p1"), Matchers.arrayContaining("v1-1", "v1-2", "v1-3"));
     Assertions.assertEquals("v1-1", requestEx.getParameter("p1"));
   }
@@ -148,7 +151,8 @@ public class TestStandardHttpServletRequestEx {
     Assertions.assertEquals("v2", requestEx.getParameter("k2"));
 
     Assertions.assertSame(parameterMap, requestEx.getParameterMap());
-
-    MatcherAssert.assertThat(Collections.list(requestEx.getParameterNames()), Matchers.contains("k1", "k2"));
+    List<String> paramList = Collections.list(requestEx.getParameterNames());
+    Collections.sort(paramList);
+    MatcherAssert.assertThat(paramList, Matchers.contains("k1", "k2"));
   }
 }

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestVertxServerRequestToHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestVertxServerRequestToHttpServletRequest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.ServletInputStream;
@@ -490,7 +491,8 @@ public class TestVertxServerRequestToHttpServletRequest {
     Assertions.assertEquals("v2", request.getParameter("k2"));
 
     Assertions.assertSame(parameterMap, request.getParameterMap());
-
-    MatcherAssert.assertThat(Collections.list(request.getParameterNames()), Matchers.contains("k1", "k2"));
+    List<String> paramList = Collections.list(request.getParameterNames());
+    Collections.sort(paramList);
+    MatcherAssert.assertThat(paramList, Matchers.contains("k1", "k2"));
   }
 }


### PR DESCRIPTION
the 4 test which I am updating are flaky tests and can fail under certain scenarios

Cause of Flakiness
The order of the elements in the list Collections.list(request.getAttributeNames() & Collections.list(request.getAttributeNames() is non deterministic and can change which can cause the test to fail in future

Fix 
I am Sorting the list before the assertion to remove non determinism. After the sorting, order will always be constant