### PR TITLE
fix flaky test sample pr

### DIFF
--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestAbstractHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestAbstractHttpServletRequest.java
@@ -39,7 +39,7 @@ public class TestAbstractHttpServletRequest {
     MatcherAssert.assertThat(Collections.list(request.getAttributeNames()), Matchers.contains(key));
 
     request.setAttribute("a2", "v");
-    MatcherAssert.assertThat(Collections.list(request.getAttributeNames()), Matchers.contains(key, "a2"));
+    MatcherAssert.assertThat(Collections.list(request.getAttributeNames()), Matchers.containsInAnyOrder(key, "a2"));
 
     request.removeAttribute(key);
     Assertions.assertNull(request.getAttribute(key));

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestStandardHttpServletRequestEx.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestStandardHttpServletRequestEx.java
@@ -131,7 +131,7 @@ public class TestStandardHttpServletRequestEx {
       }
     };
 
-    MatcherAssert.assertThat(Collections.list(requestEx.getParameterNames()), Matchers.contains("p1", "p2"));
+    MatcherAssert.assertThat(Collections.list(requestEx.getParameterNames()), Matchers.containsInAnyOrder("p1", "p2"));
     MatcherAssert.assertThat(requestEx.getParameterValues("p1"), Matchers.arrayContaining("v1-1", "v1-2", "v1-3"));
     Assertions.assertEquals("v1-1", requestEx.getParameter("p1"));
   }
@@ -149,6 +149,6 @@ public class TestStandardHttpServletRequestEx {
 
     Assertions.assertSame(parameterMap, requestEx.getParameterMap());
 
-    MatcherAssert.assertThat(Collections.list(requestEx.getParameterNames()), Matchers.contains("k1", "k2"));
+    MatcherAssert.assertThat(Collections.list(requestEx.getParameterNames()), Matchers.containsInAnyOrder("k1", "k2"));
   }
 }

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestVertxServerRequestToHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestVertxServerRequestToHttpServletRequest.java
@@ -491,6 +491,6 @@ public class TestVertxServerRequestToHttpServletRequest {
 
     Assertions.assertSame(parameterMap, request.getParameterMap());
 
-    MatcherAssert.assertThat(Collections.list(request.getParameterNames()), Matchers.contains("k1", "k2"));
+    MatcherAssert.assertThat(Collections.list(request.getParameterNames()), Matchers.containsInAnyOrder("k1", "k2"));
   }
 }


### PR DESCRIPTION
### Summary

The order in which the values are returned from `request.getAttributeNames()` and `requestEx.getParameterNames()` is non deterministic because of the use of HashMap(which doesn't guarantee the order of the elements). To make sure the assert handles these cases as well, I have used `containsInAnyOrder` instead of `contains` to make sure the tests are not flaky
